### PR TITLE
TECH-1124 - Upgrading Node.js 12 Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated, current PR upgrades them to Node.js 16