### PR TITLE
TECH-737 - Adding backoffLimit as an allowed param

### DIFF
--- a/charts/common/templates/cronjob.yaml
+++ b/charts/common/templates/cronjob.yaml
@@ -6,11 +6,11 @@ kind: CronJob
 metadata:
   name: "{{ $fullName }}-{{ $job.name }}"
 spec:
-  backoffLimit: {{ $job.backoffLimit | default "6" }}
   concurrencyPolicy: {{ $job.concurrencyPolicy }}
   failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: {{ $job.backoffLimit | default "6" }}
       template:
         metadata:
           labels:

--- a/charts/common/templates/cronjob.yaml
+++ b/charts/common/templates/cronjob.yaml
@@ -6,6 +6,7 @@ kind: CronJob
 metadata:
   name: "{{ $fullName }}-{{ $job.name }}"
 spec:
+  backoffLimit: {{ $job.backoffLimit | default "6" }}
   concurrencyPolicy: {{ $job.concurrencyPolicy }}
   failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
   jobTemplate:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -58,6 +58,7 @@ cronjob:
 #      successfulJobsHistoryLimit: 3
 #      concurrencyPolicy: Forbid
 #      restartPolicy: Never
+#      backoffLimit: 2
 #      nodeSelector:
 #        type: infra
 #      tolerations:


### PR DESCRIPTION
As far as I could see, my changes allow setting a custom value for `backoffLimit` which, AFAIK,  is `6` by default, but I would like for @OleksandrUA to confirm.