### PR TITLE
Remove default values for port and containerPort

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.12
+version: 0.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.12"
+appVersion: "0.0.13"
 icon: https://cncf-branding.netlify.app/img/projects/helm/horizontal/color/helm-horizontal-color.png

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -7,9 +7,9 @@ replicaCount: 1
 service:
   enabled: true
   name: ""
-  port: 80
+#  port: 80
   type: ClusterIP
-  containerPort: 5000
+#  containerPort: 5000
   tls:
     enabled: false
     issuerName: ""

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -5,14 +5,14 @@
 replicaCount: 1
 
 service:
-  enabled: true
-  name: ""
+#  enabled: true
+#  name: ""
 #  port: 80
-  type: ClusterIP
+#  type: ClusterIP
 #  containerPort: 5000
-  tls:
-    enabled: false
-    issuerName: ""
+#  tls:
+#    enabled: false
+#    issuerName: ""
 
 deployment:
   enabled: true
@@ -100,7 +100,7 @@ serviceAccount:
   name: ""
   # Annotations to add to the service account
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/name
+#    eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/name
 
 podAnnotations: {}
 


### PR DESCRIPTION
Having default values for `port` and `containerPort` is preventing the possibility of using `ports`, introduced in my previous PR.

Even though this is a breaking change for deployments that have not set a value for `port` and `containerPort`, I haven't seen that any of us have actually skipped declaring them. Nevertheless, deployments are using a fixed chart version, so making this change should not be an issue at all.